### PR TITLE
Bump dependencies to latest versions. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<junit-jupiter.version>5.4.0</junit-jupiter.version>
-		<spring-cloud.version>Greenwich.SR1</spring-cloud.version>
+		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>
@@ -18,7 +18,7 @@
 		<java.version>1.8</java.version>
 		<junit-jupiter.version>5.4.0</junit-jupiter.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
-		<!-- <jackson.version>2.9.9.1</jackson.version --> <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
+		<jackson.version>2.9.9.20190807</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>2.1.8.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>
@@ -16,9 +16,9 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<junit-jupiter.version>5.4.0</junit-jupiter.version>
-		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
-		<jackson.version>2.9.9.20190807</jackson.version>
+		<junit-jupiter.version>5.5.2</junit-jupiter.version>
+		<spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+		<jackson.version>2.9.10</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.5.RELEASE</version>
+		<version>2.1.6.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.4.0</version>
+			<version>5.5.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.15</version>
+			<version>8.0.16</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.h2database/h2 -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 		<java.version>1.8</java.version>
 		<junit-jupiter.version>5.4.0</junit-jupiter.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
+		<!-- <jackson.version>2.9.9.1</jackson.version --> <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Spring pulled in known-vulnerable versions of Jackson and Tomcat, among other issues.

(I'm going to merge this in my fork directly, but figured it'd be better to make a PR to "upstream" as well.)